### PR TITLE
Only consider last review from every user.

### DIFF
--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -121,9 +121,10 @@ export const getApprovalStatus = async (pullNumber) => {
 
   reviewsData.reverse().forEach(({ state, user }) => {
     if (reviewers.has(user.login)) return;
-    reviewers.add(user.login);
+    if (!['CHANGES_REQUESTED', 'APPROVED'].includes(stat)) return;
     if (state === 'CHANGES_REQUESTED') changesRequestedCount += 1;
     if (state === 'APPROVED') approvalCount += 1;
+    reviewers.add(user.login);
   });
 
   return {

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -115,10 +115,13 @@ export const getApprovalStatus = async (pullNumber) => {
     pull_number: pullNumber,
   });
 
+  let reviewers = Set();
   let changesRequestedCount = 0;
   let approvalCount = 0;
 
-  reviewsData.forEach(({ state }) => {
+  reviewsData.reverse().forEach(({ state, user }) => {
+    if (reviewers.has(user.login)) return;
+    reviewers.add(user.login);
     if (state === 'CHANGES_REQUESTED') changesRequestedCount += 1;
     if (state === 'APPROVED') approvalCount += 1;
   });

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -121,7 +121,7 @@ export const getApprovalStatus = async (pullNumber) => {
 
   reviewsData.reverse().forEach(({ state, user }) => {
     if (reviewers.has(user.login)) return;
-    if (!['CHANGES_REQUESTED', 'APPROVED'].includes(stat)) return;
+    if (!['CHANGES_REQUESTED', 'APPROVED'].includes(state)) return;
     if (state === 'CHANGES_REQUESTED') changesRequestedCount += 1;
     if (state === 'APPROVED') approvalCount += 1;
     reviewers.add(user.login);

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -115,7 +115,7 @@ export const getApprovalStatus = async (pullNumber) => {
     pull_number: pullNumber,
   });
 
-  let reviewers = Set();
+  let reviewers = new Set();
   let changesRequestedCount = 0;
   let approvalCount = 0;
 

--- a/src/lib/github.test.js
+++ b/src/lib/github.test.js
@@ -335,7 +335,7 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     const prData = {
@@ -368,7 +368,7 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     // pr mergeable: true, merge_state: clean
@@ -402,7 +402,7 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     // pr mergeable: true, merge_state: clean
@@ -449,7 +449,7 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     // pr mergeable: true, merge_state: clean

--- a/src/lib/github.test.js
+++ b/src/lib/github.test.js
@@ -243,7 +243,7 @@ describe('getApprovalStatus()', () => {
   });
 });
 
-describe('getAutoUpdateCanidate()', () => {
+describe('getAutoUpdateCandidate()', () => {
   const pullsList = require('../../test/fixtures/pulls_list.json');
   const reviewsList = require('../../test/fixtures/list_reviews.json');
   const prMetaData = require('../../test/fixtures/pr_metadata.json');
@@ -397,7 +397,7 @@ describe('getAutoUpdateCanidate()', () => {
     expect(res).toBe(null);
   });
 
-  test('PR with failed checks wonnt be selected', async () => {
+  test('PR with failed checks wont be selected', async () => {
     // has 2 approvals, no request for change review
     const reviews = {
       ...reviewsList,
@@ -452,7 +452,7 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     // pr mergeable: true, merge_state: clean

--- a/src/lib/github.test.js
+++ b/src/lib/github.test.js
@@ -329,6 +329,35 @@ describe('getAutoUpdateCandidate()', () => {
     expect(mockedGet).toHaveBeenCalledTimes(0);
     expect(res).toBe(null);
   });
+  
+  test('PR with approvals from a single users will not be selected', async () => {
+    // 2 approvals, but from the same user
+    const reviews = {
+      ...reviewsList,
+      data: [
+        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[0], state: 'APPROVED' },
+      ],
+    };
+    const prList = [{ ...pullsList.data[0], auto_merge: {} }];
+    const mockedListReviews = jest.fn().mockResolvedValue(reviews);
+    const mockedGet = jest.fn();
+
+    github.getOctokit.mockReturnValue({
+      pulls: { listReviews: mockedListReviews, get: mockedGet },
+    });
+
+    const res = await gitLib.getAutoUpdateCandidate(prList);
+    expect(mockedListReviews).toHaveBeenCalled();
+    expect(utils.log).toHaveBeenCalledTimes(2);
+    expect(utils.printFailReason).toHaveBeenCalledTimes(1);
+    expect(utils.printFailReason).toHaveBeenCalledWith(
+      prList[0].number,
+      `approvalsCount: 1, requiredApprovalCount: ${requiredApprovalCount}, changesRequestedReviews: 0`,
+    );
+    expect(mockedGet).toHaveBeenCalledTimes(0);
+    expect(res).toBe(null);
+  });
 
   test('PR with mergeable !== true will not be selected', async () => {
     // has 2 approvals, not request for change review
@@ -489,6 +518,53 @@ describe('getAutoUpdateCandidate()', () => {
     const res = await gitLib.getAutoUpdateCandidate(prList);
     expect(res).toBe(prList[0]);
   });
+  
+  test('Should ignore trailing comment reviews', async () => {
+    // has approvals, and some reviews at the end
+    const reviews = {
+      ...reviewsList,
+      data: [
+        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
+        { ...reviewsList.data[0], state: 'COMMENTED' },
+        { ...reviewsList.data[2], state: 'COMMENTED' },
+      ],
+    };
+    // pr mergeable: true, merge_state: clean
+    const prData = {
+      data: {
+        ...prMetaData.data,
+        ...{ mergeable: true, mergeable_state: 'behind' },
+      },
+    };
+
+    const check = checksList.data.check_runs[0];
+    const checks = {
+      ...checksList,
+      data: {
+        total_count: 2,
+        check_runs: [
+          { ...check, conclusion: 'success' },
+          { ...check, conclusion: 'success' },
+        ],
+      },
+    };
+
+    // has auto-merge PR
+    const prList = [{ ...pullsList.data[0], auto_merge: {} }];
+    const mockedListReviews = jest.fn().mockResolvedValue(reviews);
+    const mockedGet = jest.fn().mockResolvedValue(prData);
+    const mockedListForRef = jest.fn().mockResolvedValue(checks);
+
+    github.getOctokit.mockReturnValue({
+      pulls: { listReviews: mockedListReviews, get: mockedGet },
+      checks: { listForRef: mockedListForRef },
+    });
+
+    const res = await gitLib.getAutoUpdateCandidate(prList);
+    expect(res).toEqual(prList[0]);
+  });
+  
   test('Should return the first PR if it is all good', async () => {
     // has 2 approvals, no request for change review
     const reviews = {

--- a/src/lib/github.test.js
+++ b/src/lib/github.test.js
@@ -495,14 +495,14 @@ describe('getAutoUpdateCanidate()', () => {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'CHANGES_REQUESTED' },
+        { ...reviewsList.data[1], state: 'CHANGES_REQUESTED' },
       ],
     };
     const reviewsSecond = {
       ...reviewsList,
       data: [
         { ...reviewsList.data[0], state: 'APPROVED' },
-        { ...reviewsList.data[0], state: 'APPROVED' },
+        { ...reviewsList.data[1], state: 'APPROVED' },
       ],
     };
     // pr mergeable: true, merge_state: clean


### PR DESCRIPTION
PRs are currently only updated if they have no `request-for-change` review at all.
If the reviewer however does a new (accepting) review, a PR is ignored.

This PR fixes this issue by checking reviews in reversed order and skipping reviews when we have already seen a review for this user.

[These are the first lines of NodeJS I've written in my life. I'm not even 100% sure this is NodeJS. Please be gentle :-) ]
