### PR TITLE
fix: use octokit.rest interface for github

### DIFF
--- a/dest/index.js
+++ b/dest/index.js
@@ -31165,7 +31165,7 @@ const getOpenPRs = async () => {
     };
   }
 
-  const { data } = await octokit.pulls.list({
+  const { data } = await octokit.rest.pulls.list({
     ...repo,
     base: baseBranch,
     state: 'open',
@@ -31179,7 +31179,7 @@ const getOpenPRs = async () => {
 const updatePRBranch = async (pullNumber) => {
   const octokit = getOctokit();
   const repo = github.context.repo;
-  const { data } = await octokit.pulls.updateBranch({
+  const { data } = await octokit.rest.pulls.updateBranch({
     ...repo,
     pull_number: pullNumber,
   });
@@ -31193,7 +31193,7 @@ const updatePRBranch = async (pullNumber) => {
 const getPR = async (pullNumber) => {
   const octokit = getOctokit();
   const repo = github.context.repo;
-  const result = await octokit.pulls.get({
+  const result = await octokit.rest.pulls.get({
     ...repo,
     pull_number: pullNumber,
   });
@@ -31242,7 +31242,7 @@ const areAllChecksPassed = async (sha) => {
   const repo = github.context.repo;
   const {
     data: { check_runs },
-  } = await octokit.checks.listForRef({
+  } = await octokit.rest.checks.listForRef({
     ...repo,
     ref: sha,
   });
@@ -31262,7 +31262,7 @@ const getApprovalStatus = async (pullNumber) => {
   const repo = github.context.repo;
   const requiredApprovalCount = github_core.getInput('required_approval_count');
 
-  const { data: reviewsData } = await octokit.pulls.listReviews({
+  const { data: reviewsData } = await octokit.rest.pulls.listReviews({
     ...repo,
     pull_number: pullNumber,
   });

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -28,7 +28,7 @@ export const getOpenPRs = async () => {
     };
   }
 
-  const { data } = await octokit.pulls.list({
+  const { data } = await octokit.rest.pulls.list({
     ...repo,
     base: baseBranch,
     state: 'open',
@@ -42,7 +42,7 @@ export const getOpenPRs = async () => {
 export const updatePRBranch = async (pullNumber) => {
   const octokit = getOctokit();
   const repo = github.context.repo;
-  const { data } = await octokit.pulls.updateBranch({
+  const { data } = await octokit.rest.pulls.updateBranch({
     ...repo,
     pull_number: pullNumber,
   });
@@ -56,7 +56,7 @@ export const updatePRBranch = async (pullNumber) => {
 export const getPR = async (pullNumber) => {
   const octokit = getOctokit();
   const repo = github.context.repo;
-  const result = await octokit.pulls.get({
+  const result = await octokit.rest.pulls.get({
     ...repo,
     pull_number: pullNumber,
   });
@@ -105,7 +105,7 @@ export const areAllChecksPassed = async (sha) => {
   const repo = github.context.repo;
   const {
     data: { check_runs },
-  } = await octokit.checks.listForRef({
+  } = await octokit.rest.checks.listForRef({
     ...repo,
     ref: sha,
   });
@@ -125,7 +125,7 @@ export const getApprovalStatus = async (pullNumber) => {
   const repo = github.context.repo;
   const requiredApprovalCount = core.getInput('required_approval_count');
 
-  const { data: reviewsData } = await octokit.pulls.listReviews({
+  const { data: reviewsData } = await octokit.rest.pulls.listReviews({
     ...repo,
     pull_number: pullNumber,
   });

--- a/src/lib/github.test.js
+++ b/src/lib/github.test.js
@@ -57,7 +57,7 @@ describe('updatePRBranch()', () => {
 
   beforeEach(() => {
     github.getOctokit.mockReturnValue({
-      pulls: { updateBranch: mockedUpdateBranch },
+      rest: { pulls: { updateBranch: mockedUpdateBranch } },
     });
   });
   afterEach(() => {
@@ -86,7 +86,7 @@ describe('getPR()', () => {
   test('should send the expected parameters', async () => {
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
     github.getOctokit.mockReturnValue({
-      pulls: { get: mockedMethod },
+      rest: { pulls: { get: mockedMethod } },
     });
     const res = await gitLib.getPR(pullNumber);
 
@@ -110,7 +110,7 @@ describe('getOpenPRs()', () => {
   test('should send the expected parameters', async () => {
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
     github.getOctokit.mockReturnValue({
-      pulls: { list: mockedMethod },
+      rest: { pulls: { list: mockedMethod } },
     });
     const res = await gitLib.getOpenPRs(pullNumber);
 
@@ -134,7 +134,7 @@ describe('getOpenPRs()', () => {
 
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
     github.getOctokit.mockReturnValue({
-      pulls: { list: mockedMethod },
+      rest: { pulls: { list: mockedMethod } },
     });
     await gitLib.getOpenPRs(pullNumber);
 
@@ -155,7 +155,7 @@ describe('getOpenPRs()', () => {
 
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
     github.getOctokit.mockReturnValue({
-      pulls: { list: mockedMethod },
+      rest: { pulls: { list: mockedMethod } },
     });
     await gitLib.getOpenPRs(pullNumber);
 
@@ -183,7 +183,7 @@ describe('getMergeableStatus()', () => {
     };
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
     github.getOctokit.mockReturnValue({
-      pulls: { get: mockedMethod },
+      rest: { pulls: { get: mockedMethod } },
     });
     const status = await gitLib.getMergeableStatus();
     expect(status).toEqual(mergeableStatus);
@@ -203,7 +203,7 @@ describe('getMergeableStatus()', () => {
       .mockResolvedValueOnce(mockedResponseFinal);
 
     github.getOctokit.mockReturnValue({
-      pulls: { get: mockedMethod },
+      rest: { pulls: { get: mockedMethod } },
     });
     jest.spyOn(utils, 'wait').mockImplementation();
 
@@ -230,7 +230,7 @@ describe('areAllChecksPassed()', () => {
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
 
     github.getOctokit.mockReturnValue({
-      checks: { listForRef: mockedMethod },
+      rest: { checks: { listForRef: mockedMethod } },
     });
 
     const result = await gitLib.areAllChecksPassed(sha);
@@ -246,7 +246,7 @@ describe('areAllChecksPassed()', () => {
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
 
     github.getOctokit.mockReturnValue({
-      checks: { listForRef: mockedMethod },
+      rest: { checks: { listForRef: mockedMethod } },
     });
 
     const result = await gitLib.areAllChecksPassed(sha);
@@ -265,7 +265,7 @@ describe('areAllChecksPassed()', () => {
     const mockedMethod = jest.fn().mockResolvedValue(mockedResponse);
 
     github.getOctokit.mockReturnValue({
-      checks: { listForRef: mockedMethod },
+      rest: { checks: { listForRef: mockedMethod } },
     });
 
     const result = await gitLib.areAllChecksPassed(sha);
@@ -284,7 +284,7 @@ describe('getApprovalStatus()', () => {
     const mockedMethod = jest.fn().mockResolvedValue(reviewsList);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedMethod },
+      rest: { pulls: { listReviews: mockedMethod } },
     });
 
     const result = await gitLib.getApprovalStatus(pullNumber);
@@ -311,7 +311,7 @@ describe('getApprovalStatus()', () => {
     const mockedMethod = jest.fn().mockResolvedValue(reviews);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedMethod },
+      rest: { pulls: { listReviews: mockedMethod } },
     });
 
     const result = await gitLib.getApprovalStatus(pullNumber);
@@ -379,7 +379,7 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedGet = jest.fn();
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
+      rest: { pulls: { listReviews: mockedListReviews, get: mockedGet } },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -405,7 +405,7 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedGet = jest.fn();
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
+      rest: { pulls: { listReviews: mockedListReviews, get: mockedGet } },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -442,7 +442,7 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedGet = jest.fn().mockResolvedValue(prData);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
+      rest: { pulls: { listReviews: mockedListReviews, get: mockedGet } },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -476,7 +476,7 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedGet = jest.fn().mockResolvedValue(prData);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
+      rest: { pulls: { listReviews: mockedListReviews, get: mockedGet } },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -523,8 +523,10 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedListForRef = jest.fn().mockResolvedValue(checks);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
-      checks: { listForRef: mockedListForRef },
+      rest: {
+        pulls: { listReviews: mockedListReviews, get: mockedGet },
+        checks: { listForRef: mockedListForRef },
+      },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -572,8 +574,10 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedListForRef = jest.fn().mockResolvedValue(checks);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
-      checks: { listForRef: mockedListForRef },
+      rest: {
+        pulls: { listReviews: mockedListReviews, get: mockedGet },
+        checks: { listForRef: mockedListForRef },
+      },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -616,8 +620,10 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedListForRef = jest.fn().mockResolvedValue(checks);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
-      checks: { listForRef: mockedListForRef },
+      rest: {
+        pulls: { listReviews: mockedListReviews, get: mockedGet },
+        checks: { listForRef: mockedListForRef },
+      },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);
@@ -680,8 +686,10 @@ describe('getAutoUpdateCandidate()', () => {
     const mockedListForRef = jest.fn().mockResolvedValue(checks);
 
     github.getOctokit.mockReturnValue({
-      pulls: { listReviews: mockedListReviews, get: mockedGet },
-      checks: { listForRef: mockedListForRef },
+      rest: {
+        pulls: { listReviews: mockedListReviews, get: mockedGet },
+        checks: { listForRef: mockedListForRef },
+      },
     });
 
     const res = await gitLib.getAutoUpdateCandidate(prList);


### PR DESCRIPTION
I broke this with the node20 upgrade in #31. The `octokit.pulls`, `octokit.checks` objects are now nested inside `octokit.rest`, which broke existing usages. This was not uncovered with unit tests because the jest mocking covered this.

This PR:
1. switches all github calls to use `octokit.rest`
2. updates the unit tests accordingly


---

### Testing

Tested locally this time by running things like:

```
DEBUG="true" INPUT_TOKEN="github_pat_<pat>" GITHUB_REPOSITORY="adRise/update-pr-branch" INPUT_REQUIRE_AUTO_MERGE_ENABLED="false" INPUT_REQUIRE_PASSED_CHECKS="false" INPUT_BASE="master" INPUT_REQUIRED_APPROVAL_COUNT="0" node dest/index.js 
```

Example of errors before this fix:

```
TypeError: Cannot read properties of undefined (reading 'list')
TypeError: Cannot read properties of undefined (reading 'updateBranch') 
TypeError: Cannot read properties of undefined (reading 'checks')
```

