### PR TITLE
Allow ongoing checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ jobs:
           token: ${{ secrets.ACTION_USER_TOKEN }}
           base: 'master'
           required_approval_count: 2
-          require_passed_checks: false
+          require_passed_checks: true
+          allow_ongoing_checks: true
           sort: 'created'
           direction: 'desc'
-          require_auto_merge_enabled: false
+          require_auto_merge_enabled: true
 ```
 
 Replace the `VERSION_YOU_WANT_TO_USE` with the actual version you want to use, check the version format [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ We could retrieve this value from the repo settings through an API call but that
 
 Default: true
 
-The action will skip PRs that have failed checks.
+The action will skip PRs that have failed checks. Please note that if `allow_ongoing_checks` is not set to `true`, the action will skip PRs with ongoing checks. This may result in the failure to update PR branches when the action is triggered while checks for those PRs are still in progress.
+
+### `allow_ongoing_checks`
+
+**Optional**
+
+Default: false
+
+The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress.
 
 ### `sort`
 
@@ -76,7 +84,6 @@ Notice: this is an option provided by github rest api. In this github action, we
 
 The direction of the sort. Can be either `asc` or `desc`. Default: `desc` when sort is `created` or sort is not specified, otherwise `asc`.
 
-
 This github action doesn't set any default parameters.
 
 ### `require_auto_merge_enabled`
@@ -86,7 +93,6 @@ This github action doesn't set any default parameters.
 Check if having auto-merge enabled in the PR is required, in order for the PR to
 be considered. It defaults to `true`, but if set to `false`, all PRs are
 considered for update (not just those with auto-merge enabled).
-
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We could retrieve this value from the repo settings through an API call but that
 
 Default: true
 
-The action will skip PRs that have failed checks. Please note that if `allow_ongoing_checks` is not set to `true`, the action will skip PRs with ongoing checks. This may result in the failure to update PR branches when the action is triggered while checks for those PRs are still in progress.
+The action will skip updating PRs that have failed checks. Please note that if `allow_ongoing_checks` is set to `false`, the action will skip updating PRs with ongoing checks. This will result in the failure to update PR branches when the action is triggered while checks for those PRs are still in progress.
 
 ### `allow_ongoing_checks`
 
@@ -68,7 +68,7 @@ The action will skip PRs that have failed checks. Please note that if `allow_ong
 
 Default: false
 
-The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress.
+The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress. Note, this option works only when `require_passed_checks` is set to `true`.
 
 ### `sort`
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,12 @@ inputs:
     default: '2'
   require_passed_checks:
     required: false
-    description: 'If the action should skip PRs that have failed checks, defaults to `true`'
+    description: 'If the action should skip PRs that have failed checks, defaults to `true`. Please note that if `allow_ongoing_checks` is not set to `true`, the action will skip pull requests with ongoing checks. This may result in the failure to update PR branches when the action is triggered while checks for those pull requests are still in progress.'
     default: 'true'
+  allow_ongoing_checks:
+    required: false
+    description: 'If the action should consider PRs that have ongoing checks, defaults to `false`. The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress.'
+    default: 'false'
   require_auto_merge_enabled:
     required: false
     description: 'When set to false, the action includes PRs without auto-merge; the default true excludes such PRs.'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'true'
   allow_ongoing_checks:
     required: false
-    description: 'If the action should consider PRs that have ongoing checks, defaults to `false`. The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress.'
+    description: 'If the action should consider PRs that have ongoing checks, defaults to `false`.  The action will consider PRs that have ongoing checks. This is useful when the action is triggered while checks for some otherwise qualified PRs are still in progress. Note, this option works only when `require_passed_checks` is set to `true`.'
     default: 'false'
   require_auto_merge_enabled:
     required: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-pr-branch",
-  "version": "0.1.2",
+  "version": "0.9.0",
   "description": "Automatically update PR branch",
   "main": "dest/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "update-pr-branch",
-  "version": "0.9.0",
   "description": "Automatically update PR branch",
   "main": "dest/index.js",
   "scripts": {

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -100,7 +100,7 @@ export const getMergeableStatus = async (pullNumber) => {
 /**
  * whether all checks passed
  */
-export const areAllChecksPassed = async (sha) => {
+export const areAllChecksPassed = async (sha, allow_ongoing_checks) => {
   const octokit = getOctokit();
   const repo = github.context.repo;
   const {
@@ -110,11 +110,20 @@ export const areAllChecksPassed = async (sha) => {
     ref: sha,
   });
 
-  const hasUnfinishedOrFailedChecks = check_runs.some((item) => {
-    return item.status !== 'completed' || item.conclusion === 'failure';
-  });
+  let hasOffensiveChecks = false;
+  if (allow_ongoing_checks) {
+    // check whether there are ongoing checks
+    hasOffensiveChecks = check_runs.some((item) => {
+      return item.conclusion === 'failure';
+    });
+  } else {
+    // check whether there are unfinished or failed checks
+    hasOffensiveChecks = check_runs.some((item) => {
+      return item.status !== 'completed' || item.conclusion === 'failure';
+    });
+  }
 
-  return !hasUnfinishedOrFailedChecks;
+  return !hasOffensiveChecks;
 };
 
 /**
@@ -154,7 +163,9 @@ export const getApprovalStatus = async (pullNumber) => {
 };
 
 export const filterApplicablePRs = (openPRs) => {
-  const includeNonAutoMergePRs = isStringFalse(core.getInput('require_auto_merge_enabled'));
+  const includeNonAutoMergePRs = isStringFalse(
+    core.getInput('require_auto_merge_enabled'),
+  );
   if (includeNonAutoMergePRs) {
     return openPRs;
   }
@@ -170,6 +181,9 @@ export const getAutoUpdateCandidate = async (openPRs) => {
 
   const requirePassedChecks = isStringTrue(
     core.getInput('require_passed_checks'),
+  );
+  const allowOngoingChecks = isStringTrue(
+    core.getInput('allow_ongoing_checks'),
   );
   const applicablePRs = filterApplicablePRs(openPRs);
 
@@ -216,9 +230,13 @@ export const getAutoUpdateCandidate = async (openPRs) => {
      * need to note: the mergeable, and mergeable_state don't reflect the checks status
      */
     if (requirePassedChecks) {
-      const didChecksPass = await areAllChecksPassed(sha);
+      const didChecksPass = await areAllChecksPassed(sha, allowOngoingChecks);
+
+      const reasonType = allowOngoingChecks
+        ? 'failed check(s)'
+        : 'failed or ongoing check(s)';
       if (!didChecksPass) {
-        printFailReason(pullNumber, 'The PR has failed or ongoing check(s)');
+        printFailReason(pullNumber, `The PR has ${reasonType}`);
         continue;
       }
     }


### PR DESCRIPTION
#### Main change

add `allow_ongoing_checks` option to update PRs that have ongoing checks when the action is triggered.  close #33 
Setting `require_passed_checks` to true alone may prevent updates to PRs with ongoing checks. It is advisable to set both `require_passed_checks` and `allow_ongoing_checks` to true.