### PR TITLE
feat: upgrade action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ inputs:
     description: 'A comma-separated list of labels that the action will consider. If a PR has any of the labels, the action will consider it.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dest/index.js'

--- a/src/lib/util.test.js
+++ b/src/lib/util.test.js
@@ -59,3 +59,26 @@ describe('isStringTrue()', () => {
     expect(isStringTrue()).toBe(false);
   });
 });
+
+describe('isStringFalse()', () => {
+  const isStringFalse = utils.isStringFalse;
+  test('should return the correct value based on the string', () => {
+    expect(isStringFalse('false')).toBe(true);
+    expect(isStringFalse('False')).toBe(true);
+    expect(isStringFalse('FALSE')).toBe(true);
+    expect(isStringFalse('fAlse')).toBe(true);
+    expect(isStringFalse('true')).toBe(false);
+    expect(isStringFalse('True')).toBe(false);
+    expect(isStringFalse('TRUE')).toBe(false);
+  });
+
+  test('should return false if the string is not a boolean', () => {
+    expect(isStringFalse('something')).toBe(false);
+    expect(isStringFalse()).toBe(false);
+  });
+
+  test('should coerce non-string inputs', () => {
+    expect(isStringFalse(false)).toBe(true);
+    expect(isStringFalse(true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Bump the action runtime from `node20` to `node24` in `action.yml`. Per the [Sept 2025 GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), GitHub Actions runners will switch to Node 24 by default on **June 16, 2026**, with Node 20 fully removed in fall 2026 (see #45).
- Rebuild `dest/index.js` via `yarn build`.
- Add missing unit tests for `isStringFalse()` in `src/lib/util.js` (previously untested).

Closes #45

## Test plan
- [x] `yarn lint`
- [x] `yarn test` — 43 tests pass, 100% statement / function / line coverage
- [ ] CI green on this PR
- [ ] Smoke test the action in a downstream repo on a Node 24 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)